### PR TITLE
Don't load jQuery when payeezyjszc isn't active

### DIFF
--- a/includes/modules/pages/checkout_payment/jscript_payeezy.php
+++ b/includes/modules/pages/checkout_payment/jscript_payeezy.php
@@ -3,14 +3,14 @@
  * Javascript to prep functionality for Payeezy payment module
  *
  * @package payeezy
- * @copyright Copyright 2003-2017 Zen Cart Development Team
+ * @copyright Copyright 2003-2018 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: Ian Wilson   New in v1.5.5 $
+ * @version GIT: $Id: Author: Ian Wilson   Modified in v1.5.6 $
  */
-if (!defined(MODULE_PAYMENT_PAYEEZYJSZC_STATUS) || MODULE_PAYMENT_PAYEEZYJSZC_STATUS != 'True' || (!defined('MODULE_PAYMENT_PAYEEZYJSZC_JSSECURITY_KEY') && !defined('MODULE_PAYMENT_PAYEEZYJSZC_JSSECURITY_KEY_SANDBOX') )) {
+if (!defined('MODULE_PAYMENT_PAYEEZYJSZC_STATUS') || MODULE_PAYMENT_PAYEEZYJSZC_STATUS != 'True' || (!defined('MODULE_PAYMENT_PAYEEZYJSZC_JSSECURITY_KEY') && !defined('MODULE_PAYMENT_PAYEEZYJSZC_JSSECURITY_KEY_SANDBOX') )) {
 	return false;
 }
-if ($payment_modules->in_special_checkout()) {
+if ($payment_modules->in_special_checkout() || empty($payeezyjszc) || !$payeezyjszc->enabled) {
     return false;
 }
 ?>
@@ -94,10 +94,10 @@ var Payeezy = function() {
                 return false
             }
 
-            var a = "https://" + this.apiEndpoint + "/v1/securitytokens?apikey=" + this.apikey + "&js_security_key=" + this.js_security_key 
-                  + "&callback=Payeezy.callback&auth=" + this.auth + "&ta_token=" + this.ta_token + "&type=FDToken&credit_card.type=" + encodeURIComponent(r["card_type"]) 
-                  + "&credit_card.cardholder_name=" + encodeURIComponent(r["cardholder_name"]) + "&credit_card.card_number=" + r["cc_number"].replace(/[^0-9]/g,'') 
-                  + "&credit_card.exp_date=" + r["exp_month"].replace(/[^0-9]/g,'') + r["exp_year"].replace(/[^0-9]/g,'') 
+            var a = "https://" + this.apiEndpoint + "/v1/securitytokens?apikey=" + this.apikey + "&js_security_key=" + this.js_security_key
+                  + "&callback=Payeezy.callback&auth=" + this.auth + "&ta_token=" + this.ta_token + "&type=FDToken&credit_card.type=" + encodeURIComponent(r["card_type"])
+                  + "&credit_card.cardholder_name=" + encodeURIComponent(r["cardholder_name"]) + "&credit_card.card_number=" + r["cc_number"].replace(/[^0-9]/g,'')
+                  + "&credit_card.exp_date=" + r["exp_month"].replace(/[^0-9]/g,'') + r["exp_year"].replace(/[^0-9]/g,'')
                   + "&credit_card.cvv=" + r["cvv_code"].replace(/[^0-9]/g,'');
 
             if (r["currency"]        != undefined) a = a + "&currency=" + encodeURIComponent(r["currency"]);


### PR DESCRIPTION
Also includes some (apparent) discrepancies between the module, as present in the zencart/v156 branch, see line 10 and 101.  The version on zc56 does not include that credit_cart.cvv value, while the current version on the payeezyjs repository does.

Resolves #4 